### PR TITLE
Base for Reflections and Refraction/Transparency

### DIFF
--- a/src/rendering/trace_ray.c
+++ b/src/rendering/trace_ray.c
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <math.h>
 #include "libft_printf.h"
 #include "minirt.h"
 
@@ -30,6 +31,95 @@ static void	shade(t_minirt *env, t_ray *ray)
 		set_secondary_ray(hit_obj, ray);
 		trace_ray_to_lights(env, ray);
 	}
+}
+
+/*
+** (Pull requested by 0auBSQ)
+** (To move to an external file, contains vector * float operation, vector reflection and refraction deviation calculus, taken from my RT)
+*/
+
+t_vec3	v3dotf(t_vec3 v, double f)
+{
+	t_vec3	r;
+
+	r.x = v.x * f;
+	r.y = v.y * f;
+	r.z = v.z * f;
+	return (r);
+}
+
+t_vec3	v3reflect(t_vec3 i, t_vec3 n)
+{
+	t_vec3	r;
+	double	double_dot;
+
+	double_dot = 2. * (i.x * n.x + i.y * n.y + i.z * n.z);
+	r.x = i.x - double_dot * n.x;
+	r.y = i.y - double_dot * n.y;
+	r.z = i.z - double_dot * n.z;
+	return (r);
+}
+
+t_vec3	v3refract(t_vec3 i, t_vec3 n, double indice)
+{
+	double	cosi;
+	double	etai;
+	double	eta;
+	double	k;
+
+	cosi = dot_vec3(i, n);
+	cosi = (cosi > 1) ? 1 : cosi;
+	cosi = (cosi < -1) ? -1 : cosi;
+	etai = 1;
+	if (cosi < 0)
+		cosi = -cosi;
+	else
+	{
+		indice = 1;
+		etai = indice;
+		n = v3dotf(n, -1);
+	}
+	if (indice <= 0.1)
+		indice = 1.;
+	eta = etai / indice;
+	k = 1 - eta * eta * (1 - cosi * cosi);
+	return ((k < 0) ? (t_vec3){0, 0, 0}
+		: add_vec3(v3dotf(i, eta), v3dotf(n, eta * cosi - sqrt(k))));
+}
+
+/*
+** (Pull requested by 0auBSQ)
+** (Raw) Recurrsive Reflection and refraction handling (Few refractions per pixel so no stack overflow risks)
+** To do : 
+** - Add REFLECT (Reflection factor), REFRACT (Refraction indice) and TRANSPARENCY (Transparency factor) within the file definition, replace the placeholder by the parsed values
+** - Use vec4 instead of vec3 for colors (add a w variable for alpha scale)
+** - Move RECURSIVE_REFLECTION_HITS and RECURSIVE_REFRACTION_HITS in the header file
+** - side have to be set to -1 if camera is inside the object (Handler for in/out refraction deviation)
+** - Fix the distance = 0 issue to avoid the ray to stick at the object surface (ignore hit if distance from origin to hit = 0) and eventually add an epsilon to make transparency and refraction work correctly
+*/
+
+#define REFLECT 0.25
+#define REFRACT 1.50
+#define TRANSPARENCY 0.8
+#define RECURSIVE_REFLECTION_HITS 2
+#define RECURSIVE_REFRACTION_HITS 0
+
+t_vec3		shade_ray(t_minirt *env, t_ray ray, int layer, int refr_layer, int side) {
+	shade(env, &ray);
+	//printf("hit %f %f %f layer %d origin %f %f %f nearest %f\n", ray.hit_p.x, ray.hit_p.y, ray.hit_p.z, refr_layer, ray.origin.x, ray.origin.y, ray.origin.z, ray.t_nearest);
+	// Reflection
+	if (ray.t_nearest != INFINITY && layer > 0 && REFLECT >= 0.01) {
+		ray.dir = v3reflect(ray.dir, ray.normal);
+		ray.origin = ray.hit_p;
+		ray.vcolor = add_vec3(v3dotf(ray.vcolor, 1. - REFLECT), v3dotf(shade_ray(env, ray, layer - 1, refr_layer, side), REFLECT));
+	}
+	// Refraction
+	if (ray.t_nearest != INFINITY && refr_layer > 0 && TRANSPARENCY >= 0.01) {
+		ray.dir = v3refract(ray.dir, ray.normal, pow(REFRACT, side));
+		ray.origin = ray.hit_p;
+		ray.vcolor = add_vec3(v3dotf(ray.vcolor, 1. - TRANSPARENCY), v3dotf(shade_ray(env, ray, layer, refr_layer - 1, -side), TRANSPARENCY));
+	}
+	return (ray.vcolor);
 }
 
 /*
@@ -54,11 +144,11 @@ void		trace_ray(t_minirt *env, t_camera *cam, t_image *img)
 		while (x < env->res.size_x)
 		{
 			set_ray_dir(cam, &ray, get_pixel_coord(cam->fov, env->res, x, y));
-			shade(env, &ray);
+			t_vcolor col = shade_ray(env, ray, RECURSIVE_REFLECTION_HITS, RECURSIVE_REFRACTION_HITS, 1);
 #ifdef DEBUG
 			ray.vcolor = map_normal(&ray);
 #endif /* DEBUG */
-			put_pixel_to_image(img, ray.vcolor, x, y);
+			put_pixel_to_image(img, col, x, y);
 			x++;
 		}
 		y++;


### PR DESCRIPTION
Doesn't follow the 42 norm yet and still hard coded, but you could easily adapt it with the parsing :)
Still some bugs about the transparency to investigate (Certainly the distance = 0 thing)
Both Reflection and Transparency create N times a new ray at each hit, with N the max recursive factor set in the define.
Reflected rays are deviated depending of the surface normal vector, Refracted rays are computed using the Snell Descartes law.

You can disable both reflection and refraction by setting RECURSIVE_REFLECTION_HITS and RECURSIVE_REFRACTION_HITS to 0 (The program will then execute as before), in this demo reflection is applied to all objects with a depth layer of 2.